### PR TITLE
Add blinker to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+blinker==1.6.2 # Added manualy
 bs4==0.0.1
 chardet==4.0.0
 connexion==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-blinker==1.6.2 # Added manualy
+# It is useful because connexion  2.14.2 requires Flask <2.3,
+# which in turn is missing this dependency. Can be removed after Flask 2.3
+blinker==1.6.2 # Added manually, to be removed later.
 bs4==0.0.1
 chardet==4.0.0
 connexion==2.6.0


### PR DESCRIPTION
Чинит обновление от dependabot. Там обновление `connexion` до `2.14.2` требует `Flask` версии `<2.3`, который не требует `blinker` в зависимостях