### PR TITLE
[fix practice_add_new_report] Add a condition to check if the practice supervisor is selected.

### DIFF
--- a/src/flask_se_practice.py
+++ b/src/flask_se_practice.py
@@ -415,7 +415,7 @@ def practice_add_new_report(current_thesis):
                 "Слишком короткое описание дальнейших планов, напишите подробнее!",
                 category="error",
             )
-        elif not current_thesis.supervisor_id:
+        elif current_thesis.supervisor_id is None:
             flash(
                 "Научный руководитель не найден, выберите научного руководителя в разделе \"Выбор темы\"!",
                 category="error",

--- a/src/flask_se_practice.py
+++ b/src/flask_se_practice.py
@@ -417,7 +417,7 @@ def practice_add_new_report(current_thesis):
             )
         elif current_thesis.supervisor_id is None:
             flash(
-                "Научный руководитель не найден, выберите научного руководителя в разделе \"Выбор темы\"!",
+                'Научный руководитель не найден, выберите научного руководителя в разделе "Выбор темы"!',
                 category="error",
             )
         else:

--- a/src/flask_se_practice.py
+++ b/src/flask_se_practice.py
@@ -415,6 +415,11 @@ def practice_add_new_report(current_thesis):
                 "Слишком короткое описание дальнейших планов, напишите подробнее!",
                 category="error",
             )
+        elif not current_thesis.supervisor_id:
+            flash(
+                "Научный руководитель не найден, выберите научного руководителя в разделе \"Выбор темы\"!",
+                category="error",
+            )
         else:
             new_report = ThesisReport(
                 was_done=was_done,


### PR DESCRIPTION
## Description
If a new report is added while the practice supervisor is not selected, the application crashes with 500: Internal Server Error.

This PR fixes this error and suggests the user to select the supervisor via a flash error message.

## Steps to reproduce the bug
1. Go to https://se.math.spbu.ru/practice or a locally hosted alternative 
2. Add a new practice via the button "Новая работа". 
3. Do NOT select a supervisor (note that the service allows to create a new practice without a name and without supervisor selected). 
4. In the created practice go to "Отчётность". 
5. Add a new report

## Context
This line tries to find a supervisor but fails because `current_thesis.supervisor_id` is `None`
https://github.com/spbu-se/spbu_se_site/blob/2cd65d25a6c9bde8a265b1713e7240fe8bae81f6/src/flask_se_practice.py#L429

<img width="1680" alt="Screenshot 2024-03-02 at 13 49 21" src="https://github.com/spbu-se/spbu_se_site/assets/64229743/fd386ef6-dba5-4626-9f93-e20755272d97">

## Suggested solution
A condition is added to check if the supervisor is selected. In case if the supervisor is not selected flash an error message which suggests to select the supervisor.

## Alternative solution
Prohibit to create a new practice unless a supervisor is selected.