### PR TITLE
Refactor: обновил контакты в FAQ, ссылку на "Спроси про ПИ и ТП"

### DIFF
--- a/src/templates/frequently_asked_questions.html
+++ b/src/templates/frequently_asked_questions.html
@@ -21,7 +21,7 @@
                         <p class="lead">Собрали основные вопросы про обучение на Программной инженерии (ПИ), Технологии программирования (ТП) и в целом на мат-мехе СПбГУ. Даём краткие ответы. За формальным и точным ответом лучше обращаться в <a href="https://abiturient.spbu.ru/" target="_blank">приёмную комиссию</a> напрямую, мы можем ошибаться в нюансах.</p>
                         <!-- Meta -->
                         <p>Автор ответов на вопросы: Алан Гамаонов (студент направления "Программная инженерия").</p>
-                        <p class="text-sm">Остались вопросы? Задавай в <a href="https://t.me/sysprog2020admission" target="_blank">Telegram чате</a>!<br>
+                        <p class="text-sm">Остались вопросы? Задавай в <a href="https://t.me/sysprog_admission" target="_blank">Telegram чате</a>!<br>
                             Хочешь спросить лично? Пиши! Telegram: <a href="http://t.me/Homka122" target="_blank">@Homka122</a> или в Вконтакте <a
                                 href="https://vk.com/homka122" target="_blank">Хома Комбаев</a> (или <a href="https://vk.com/end1ess_nameless"
                                 target="_blank">Алан Гамаонов</a>).

--- a/src/templates/frequently_asked_questions.html
+++ b/src/templates/frequently_asked_questions.html
@@ -22,11 +22,14 @@
                         <!-- Meta -->
                         <p>Автор ответов на вопросы: Алан Гамаонов (студент направления "Программная инженерия").</p>
                         <p class="text-sm">Остались вопросы? Задавай в <a href="https://t.me/sysprog2020admission" target="_blank">Telegram чате</a>!<br>
-                            Хочешь спросить лично? Пиши! Telegram: <a href="http://t.me/GamaonovAB" target="_blank">@GamaonovAB</a> или в Вконтакте <a href="https://vk.com/end1ess_nameless" target="_blank">Алан Гамаонов</a>.
+                            Хочешь спросить лично? Пиши! Telegram: <a href="http://t.me/Homka122" target="_blank">@Homka122</a> или в Вконтакте <a
+                                href="https://vk.com/homka122" target="_blank">Хома Комбаев</a> (или <a href="https://vk.com/end1ess_nameless"
+                                target="_blank">Алан Гамаонов</a>).
                         </p>
                         <div class="media align-items-center pt-2">
                             <div class="media-body">
-                                <span class="text-sm text-muted">Обновлено 30 Марта 2021г.</span>
+                                <span class="text-sm text-muted">Контакты обновлены 26 Апреля 2025г.<br/></span>
+                                <span class="text-sm text-muted">Вопросы обновлены 30 Марта 2021г.</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Абитуриент, который заходит в раздел FAQ встречает информацию о том, что вопросы были последний раз обновлены в 2021 году и невалидную ссылку на профиль в телеграмм

### Изменения
- Удалил ссылку на невалидный тг профиль
- Добавил себя в качестве человека, которому можно задать вопрос
- Обновил ссылку на чатик "Спроси про ПИ и ТП"
- Добавил дату обновления контактов

![image](https://github.com/user-attachments/assets/2c63c5ee-bcc0-4a3c-9fe5-589aaf82c182)
